### PR TITLE
add github backend, add cluster list, improve ssh key logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ GOLANGCI_LINT_VERSION ?= v1.60.1
 MOCKGEN_VERSION ?= v0.4.0
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 MOCKGEN ?= $(LOCALBIN)/mockgen-$(MOCKGEN_VERSION)
+LOCAL_TOOLS ?= ${GOLANGCI_LINT} ${MOCKGEN}
 INFRASTRUCTURE_PROVIDERS ?= linode
 BACKEND_PROVIDERS ?= s3
+
 all: clean fmt test vet build
 
 .PHONY: build
@@ -38,6 +40,9 @@ generate: mockgen
 	@$(MOCKGEN) -destination=providers/infrastructure/mock/mock_types.go -source=providers/infrastructure/types.go
 
 
+.PHONY: quick-build
+quick-build: clean build
+
 .PHONY: vet
 vet:
 	go vet ./...
@@ -62,8 +67,11 @@ $(MOCKGEN): $(LOCALBIN)
 
 .PHONY: clean
 clean:
-	-rm -f $(BUILD_TARGET)
-	-rm -f $(LOCALBIN)
+	@rm -f $(BUILD_TARGET)
+	@for tool in $(LOCAL_TOOLS); do \
+		rm -f $${tool} ; \
+	done
+
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note: Using devbox will install necessary requirements to build/run this project
 
 ## Getting started
 Note: if you are using devbox, enter into a shell using `devbox shell` before running these commands to use its integration.
-1. Build `clusterct-bootstrap`
+1. Build `clusterctl-bootstrap`
     ```shell
     make all
     ```

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -22,14 +22,9 @@ import (
 // clusterCmd represents the cluster command.
 var clusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	RunE: runBootstrapCluster,
+	Short: "",
+	Long:  ``,
+	RunE:  runBootstrapCluster,
 }
 
 type clusterOptions struct {
@@ -87,7 +82,16 @@ func runBootstrapCluster(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	manifestFileName := filepath.Base(manifestFile)
-	values := &types.Values{ManifestFile: manifestFileName}
+	values := &types.Values{
+		ManifestFile: manifestFileName,
+	}
+	if os.Getenv("AUTHORIZED_KEYS") != "" {
+		keys := os.Getenv("AUTHORIZED_KEYS")
+		values.SSHAuthorizedKeys = strings.Split(keys, ",")
+		klog.V(4).Infof("using ssh public key(s) %s", values.SSHAuthorizedKeys)
+	} else {
+		klog.V(4).Infof("no ssh public key(s) were specified")
+	}
 	values.ManifestFS = os.DirFS(filepath.Dir(manifestFile))
 	if manifestFileName == "-" {
 		values.ManifestFS = cloudinit.IoFS{Reader: cmd.InOrStdin()}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,13 +12,8 @@ import (
 // deleteCmd represents the delete command.
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "",
+	Long:  ``,
 	Args: func(_ *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			return errors.New("please specify a cluster name")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -8,13 +8,8 @@ import (
 // getCmd represents the get command.
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "",
+	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		klog.Info("get called")
 	},

--- a/cmd/get_kubeconfig.go
+++ b/cmd/get_kubeconfig.go
@@ -24,13 +24,8 @@ import (
 // kubeconfigCmd represents the kubeconfig command.
 var kubeconfigCmd = &cobra.Command{
 	Use:   "kubeconfig",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "get kubeconfig for a cluster",
+	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetKubeconfig(cmd, args[0])
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,4 +32,6 @@ func Execute(version, commit, date string) {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $XDG_HOME_CONFIG/.capi-bootstrap.yaml)")
+	rootCmd.PersistentFlags().StringVar(&clusterOpts.backend, "backend", "file",
+		"The backend provider to use with "+AppName)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.30.4
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.28
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.59.0
+	github.com/google/go-github/v63 v63.0.0
 	github.com/google/uuid v1.6.0
 	github.com/helloyi/go-sshclient v1.2.0
 	github.com/k3s-io/cluster-api-k3s v0.1.10-0.20240507063454-ae3b2166b1b9
@@ -81,6 +82,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,9 +172,14 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v63 v63.0.0 h1:13xwK/wk9alSokujB9lJkuzdmQuVn2QCPeck76wR3nE=
+github.com/google/go-github/v63 v63.0.0/go.mod h1:IqbcrgUmIcEaioWrGYei/09o+ge5vhffGOcxrO0AfmA=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/providers/backend/backend.go
+++ b/providers/backend/backend.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"capi-bootstrap/providers/backend/file"
+	"capi-bootstrap/providers/backend/github"
 	"capi-bootstrap/providers/backend/s3"
 )
 
@@ -9,6 +10,8 @@ func NewProvider(name string) Provider {
 	switch name {
 	case "s3":
 		return s3.NewBackend()
+	case "github":
+		return github.NewBackend()
 	default:
 		return file.NewBackend()
 	}

--- a/providers/backend/file/file.go
+++ b/providers/backend/file/file.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 	k8syaml "sigs.k8s.io/yaml"
 
+	"capi-bootstrap/types"
 	capiYaml "capi-bootstrap/yaml"
 )
 
@@ -27,6 +29,10 @@ func (b *Backend) WriteConfig(ctx context.Context, clusterName string, config *v
 
 func (b *Backend) WriteFiles(ctx context.Context, clusterName string, cloudInitFile *capiYaml.Config) ([]string, error) {
 	panic("implement me")
+}
+
+func (b *Backend) ListClusters(_ context.Context) ([]types.ClusterInfo, error) {
+	return nil, errors.New("[file backend] ListClusters not implemented")
 }
 
 type Backend struct {

--- a/providers/backend/github/github.go
+++ b/providers/backend/github/github.go
@@ -22,11 +22,7 @@ import (
 	capiYaml "capi-bootstrap/yaml"
 )
 
-const (
-	defaultRepoName   = "capi-bootstrap"
-	defaultOrgName    = "linode"
-	defaultBranchName = "main"
-)
+const defaultBranchName = "main"
 
 func NewBackend() *Backend {
 	return &Backend{
@@ -64,13 +60,11 @@ func (b *Backend) PreCmd(ctx context.Context, clusterName string) error {
 
 	klog.V(4).Infof("[github backend] opts: %+v", b)
 	if b.Org == "" {
-		klog.Infof("GITHUB_ORG is not set, defaulting to %s", defaultOrgName)
-		b.Org = defaultOrgName
+		return errors.New("GITHUB_ORG is required")
 	}
 
 	if b.Repo == "" {
-		klog.Infof("GITHUB_REPO is not set, defaulting to %s", defaultRepoName)
-		b.Repo = defaultRepoName
+		return errors.New("GITHUB_REPO is required")
 	}
 
 	if b.branchName == "" {

--- a/providers/backend/github/github.go
+++ b/providers/backend/github/github.go
@@ -307,7 +307,7 @@ func (b *Backend) writeFile(ctx context.Context, clusterName string, cloudInitFi
 	}
 	remotePath := path.Join("clusters", clusterName, "files", cloudInitFile.Path)
 
-	downloadUrl, err := b.uploadFile(ctx, cloudInitFile.Content, remotePath, clusterName)
+	downloadURL, err := b.uploadFile(ctx, cloudInitFile.Content, remotePath, clusterName)
 	if err != nil {
 		return "", nil, fmt.Errorf("couldn't upload object: %v", err)
 	}
@@ -315,7 +315,7 @@ func (b *Backend) writeFile(ctx context.Context, clusterName string, cloudInitFi
 	cloudInitFile.Content = ""
 	klog.V(4).Infof("[github backend] updated existing state file %s for cluster %s in remote repo %s/%s", remotePath, clusterName, b.Org, b.Repo)
 
-	downloadCmd := fmt.Sprintf("curl -sL -H 'Accept: application/vnd.github.raw+json' -H 'Authorization: Bearer %s' -H 'X-GitHub-Api-Version: 2022-11-28' '%s' | xargs -0 cloud-init query -f > %s", b.Token, downloadUrl, cloudInitFile.Path)
+	downloadCmd := fmt.Sprintf("curl -sL -H 'Accept: application/vnd.github.raw+json' -H 'Authorization: Bearer %s' -H 'X-GitHub-Api-Version: 2022-11-28' '%s' | xargs -0 cloud-init query -f > %s", b.Token, downloadURL, cloudInitFile.Path)
 	return downloadCmd, &cloudInitFile, nil
 }
 

--- a/providers/backend/github/github.go
+++ b/providers/backend/github/github.go
@@ -1,0 +1,399 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v63/github"
+	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"k8s.io/klog/v2"
+	k8syaml "sigs.k8s.io/yaml"
+
+	"capi-bootstrap/types"
+	"capi-bootstrap/utils"
+	capiYaml "capi-bootstrap/yaml"
+)
+
+const (
+	defaultRepoName   = "capi-bootstrap"
+	defaultOrgName    = "linode"
+	defaultBranchName = "main"
+)
+
+func NewBackend() *Backend {
+	return &Backend{
+		Name:       "github",
+		Repo:       os.Getenv("GITHUB_REPO"),
+		Org:        os.Getenv("GITHUB_ORG"),
+		Token:      os.Getenv("GITHUB_TOKEN"),
+		clusters:   make(map[string]*v1.Config),
+		branchName: os.Getenv("GITHUB_BRANCH"),
+	}
+}
+
+type CreateBranchOptions struct {
+	Ref string `json:"ref"`
+	Sha string `json:"sha"`
+}
+
+type Backend struct {
+	Name  string
+	Org   string
+	Repo  string
+	Token string
+
+	client     *github.Client
+	user       *github.User
+	branch     *github.Branch
+	branchName string
+	clusters   map[string]*v1.Config
+}
+
+func (b *Backend) PreCmd(ctx context.Context, clusterName string) error {
+	if b.Token == "" {
+		return errors.New("GITHUB_TOKEN is required")
+	}
+
+	klog.V(4).Infof("[github backend] opts: %+v", b)
+	if b.Org == "" {
+		klog.Infof("GITHUB_ORG is not set, defaulting to %s", defaultOrgName)
+		b.Org = defaultOrgName
+	}
+
+	if b.Repo == "" {
+		klog.Infof("GITHUB_REPO is not set, defaulting to %s", defaultRepoName)
+		b.Repo = defaultRepoName
+	}
+
+	if b.branchName == "" {
+		klog.Infof("GITHUB_BRANCH is not set, defaulted to %s", defaultBranchName)
+		b.branchName = defaultBranchName
+	}
+
+	klog.V(4).Infof("[github backend] trying to validate existing state repo %s/%s for cluster %s", b.Org, b.Repo, clusterName)
+
+	client, user, err := authenticate(ctx, b.Token, b.Org, b.Repo)
+	if err != nil {
+		return fmt.Errorf("[github backend] failed to authenticate to repo %s/%s: %v", b.Org, b.Repo, err)
+	}
+	b.client = client
+	b.user = user
+
+	branch, httpResp, err := b.client.Repositories.GetBranch(context.Background(), b.Org, b.Repo, b.branchName, 2)
+	if err != nil && httpResp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("[github backend] unexpected error when checking for branch %s: %v", b.branchName, err)
+	} else {
+		b.branch = branch
+	}
+
+	klog.Infof("[github backend] successfully authenticated to state repo %s/%s using branch %s", b.Org, b.Repo, b.branchName)
+
+	return nil
+}
+
+func (b *Backend) Read(ctx context.Context, clusterName string) (*v1.Config, error) {
+	client := b.client
+	klog.V(4).Infof("[github backend] trying to read state file %s/%s from branch %s in repo %s/%s", clusterName, "kubeconfig.yaml", b.branchName, b.Org, b.Org)
+
+	if b.branch != nil {
+		file, _, _, err := client.Repositories.GetContents(ctx, b.Org, b.Repo, path.Join("clusters", clusterName, "kubeconfig.yaml"), &github.RepositoryContentGetOptions{
+			Ref: b.branchName,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		rawStateFile, err := file.GetContent()
+		if err != nil {
+			return nil, err
+		}
+
+		kubeconfig := strings.NewReader(rawStateFile)
+
+		rawKubeconfig, err := io.ReadAll(kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		js, err := k8syaml.YAMLToJSON(rawKubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		var config v1.Config
+		if err := json.Unmarshal(js, &config); err != nil {
+			return nil, err
+		}
+
+		return &config, nil
+	}
+
+	return nil, fmt.Errorf("[github backend] branch %s may not exist in repo %s/%s", b.branchName, b.Org, b.Repo)
+}
+
+func (b *Backend) Delete(ctx context.Context, clusterName string) error {
+	klog.V(4).Infof("[github backend] trying to delete state files in remote repo: %s", clusterName)
+
+	branch, _, err := b.client.Repositories.GetBranch(ctx, b.Org, b.Repo, b.branchName, 2)
+	if err != nil {
+		return err
+	}
+	b.branch = branch
+	tree, _, err := b.client.Git.GetTree(ctx, b.Org, b.Repo, b.branch.Commit.GetSHA(), true)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range tree.Entries {
+		if strings.HasPrefix(entry.GetPath(), path.Join("clusters", clusterName)) {
+			// set content and sha to nil, which tells git you are deleting this file
+			entry.SHA = nil
+			entry.Content = nil
+			continue
+		}
+	}
+
+	nt, _, err := b.client.Git.CreateTree(ctx, b.Org, b.Repo, b.branch.Commit.GetSHA(), tree.Entries)
+	if err != nil {
+		return err
+	}
+
+	// If you use the `/repos/{owner}/{repo}/git/trees` endpoint to add, delete, or modify the file contents in a tree,
+	// you will need to commit the tree and then update a branch to point to the commit.
+	// For more information see "Create a commit" and "Update a reference."
+
+	commit := &github.Commit{
+		SHA:  nt.SHA,
+		Tree: nt,
+		Author: &github.CommitAuthor{
+			Date: &github.Timestamp{
+				Time: time.Now(),
+			},
+			Name:  b.user.Name,
+			Email: b.user.Email,
+			Login: b.user.Login,
+		},
+		Parents: b.branch.GetCommit().Parents,
+		Message: PointerTo(fmt.Sprintf("deleting state files for cluster %s", clusterName)),
+		//Verification: nil, // TODO sign commits
+	}
+
+	newCommit, _, err := b.client.Git.CreateCommit(ctx, b.Org, b.Repo, commit, &github.CreateCommitOptions{})
+	if err != nil {
+		return err
+	}
+
+	ref := &github.Reference{
+		Ref: PointerTo(path.Join("heads", b.branch.GetName())),
+		Object: &github.GitObject{
+			Type: PointerTo("commit"),
+			SHA:  newCommit.SHA,
+		},
+	}
+
+	if _, _, err = b.client.Git.UpdateRef(ctx, b.Org, b.Repo, ref, true); err != nil {
+		return err
+	}
+
+	klog.Infof("[github backend] deleted all state files from branch %s in github repo %s/%s ", clusterName, b.Org, b.Repo)
+
+	return nil
+}
+
+func (b *Backend) ListClusters(ctx context.Context) ([]types.ClusterInfo, error) {
+	_, clusterConfigs, _, err := b.client.Repositories.GetContents(ctx, b.Org, b.Repo, "clusters", &github.RepositoryContentGetOptions{
+		Ref: b.branchName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cluster := range clusterConfigs {
+		if cluster.GetType() != "dir" {
+			klog.Warningf("expected remote content to be a directory, but was a %s instead", cluster.GetType())
+			continue
+		}
+		rawKC, _, _, err := b.client.Repositories.GetContents(ctx, b.Org, b.Repo, path.Join("clusters", *cluster.Name, "kubeconfig.yaml"), &github.RepositoryContentGetOptions{
+			Ref: b.branchName,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		kc, err := rawKC.GetContent()
+		if err != nil {
+			return nil, err
+		}
+
+		kubeconfig := strings.NewReader(kc)
+
+		rawKubeconfig, err := io.ReadAll(kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		config := &v1.Config{}
+		err = k8syaml.Unmarshal(rawKubeconfig, config)
+		if err != nil {
+			return nil, err
+		}
+
+		b.clusters[*cluster.Name] = config
+	}
+
+	clusters := make([]types.ClusterInfo, len(b.clusters))
+	for name, conf := range b.clusters {
+		kubeconfig, err := capiYaml.Marshal(conf)
+		if err != nil {
+			return nil, err
+		}
+		list, err := utils.BuildNodeInfoList(ctx, kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+		clusters = append(clusters, types.ClusterInfo{
+			Name:  name,
+			Nodes: list,
+		})
+	}
+
+	return clusters, nil
+}
+
+func (b *Backend) WriteConfig(ctx context.Context, clusterName string, config *v1.Config) error {
+	js, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	y, err := k8syaml.JSONToYAML(js)
+	if err != nil {
+		return err
+	}
+	filePath := path.Join("clusters", clusterName, "kubeconfig.yaml")
+	_, err = b.uploadFile(ctx, string(y), filePath, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to write cluster %s config: %v", clusterName, err)
+	}
+	return nil
+}
+
+func (b *Backend) WriteFiles(ctx context.Context, clusterName string, cloudInitConfig *capiYaml.Config) ([]string, error) {
+	downloadCmds := make([]string, len(cloudInitConfig.WriteFiles))
+	newFiles := make([]capiYaml.InitFile, len(cloudInitConfig.WriteFiles))
+	for i, file := range cloudInitConfig.WriteFiles {
+		newCmd, newFile, err := b.writeFile(ctx, clusterName, file)
+		if err != nil {
+			return nil, err
+		}
+		downloadCmds[i] = newCmd
+		newFiles[i] = *newFile
+	}
+	cloudInitConfig.WriteFiles = newFiles
+	return downloadCmds, nil
+}
+
+func (b *Backend) writeFile(ctx context.Context, clusterName string, cloudInitFile capiYaml.InitFile) (string, *capiYaml.InitFile, error) {
+	if cloudInitFile.Content == "" {
+		return "", nil, errors.New("cloudInitFile content is empty")
+	}
+	remotePath := path.Join("clusters", clusterName, "files", cloudInitFile.Path)
+
+	downloadUrl, err := b.uploadFile(ctx, cloudInitFile.Content, remotePath, clusterName)
+	if err != nil {
+		return "", nil, fmt.Errorf("couldn't upload object: %v", err)
+	}
+
+	cloudInitFile.Content = ""
+	klog.V(4).Infof("[github backend] updated existing state file %s for cluster %s in remote repo %s/%s", remotePath, clusterName, b.Org, b.Repo)
+
+	downloadCmd := fmt.Sprintf("curl -sL -H 'Accept: application/vnd.github.raw+json' -H 'Authorization: Bearer %s' -H 'X-GitHub-Api-Version: 2022-11-28' '%s' | xargs -0 cloud-init query -f > %s", b.Token, downloadUrl, cloudInitFile.Path)
+	return downloadCmd, &cloudInitFile, nil
+}
+
+func (b *Backend) uploadFile(ctx context.Context, fileContent string, remotePath string, clusterName string) (string, error) {
+	// need config for the SHA
+	config, _, httpResp, err := b.client.Repositories.GetContents(ctx, b.Org, b.Repo, remotePath, &github.RepositoryContentGetOptions{
+		Ref: b.branchName,
+	})
+	if err != nil {
+		switch httpResp.StatusCode {
+		case http.StatusNotFound, http.StatusOK, http.StatusFound, http.StatusNotModified:
+			// expected
+		case http.StatusForbidden:
+			return "", fmt.Errorf("failed to upload state file %s due to permissions error: %w", remotePath, err)
+		default:
+			return "", err
+		}
+	}
+
+	var contentResp *github.RepositoryContentResponse
+	switch httpResp.StatusCode {
+	// https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content--status-codes
+	case http.StatusNotFound:
+		// create
+		contentResp, _, err = b.client.Repositories.CreateFile(ctx, b.Org, b.Repo, remotePath, &github.RepositoryContentFileOptions{
+			Content: []byte(fileContent),
+			Branch:  PointerTo(b.branchName),
+			Committer: &github.CommitAuthor{
+				Date:  &github.Timestamp{Time: time.Now()},
+				Name:  b.user.Name,
+				Email: b.user.Email,
+				Login: b.user.Login,
+			},
+			Message: PointerTo(fmt.Sprintf("creating cluster %s state file", clusterName)),
+		})
+		if err != nil {
+			return "", err
+		}
+
+	default:
+		// update
+		contentResp, _, err = b.client.Repositories.UpdateFile(ctx, b.Org, b.Repo, remotePath, &github.RepositoryContentFileOptions{
+			Content: []byte(fileContent),
+			Branch:  PointerTo(b.branchName),
+			Committer: &github.CommitAuthor{
+				Date:  &github.Timestamp{Time: time.Now()},
+				Name:  b.user.Name,
+				Email: b.user.Email,
+				Login: b.user.Login,
+			},
+			SHA:     config.SHA,
+			Message: PointerTo(fmt.Sprintf("updating cluster %s state file", clusterName)),
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+	return contentResp.Content.GetDownloadURL(), nil
+}
+
+func authenticate(ctx context.Context, token, org, repo string) (*github.Client, *github.User, error) {
+	client := github.NewClient(nil).WithAuthToken(token)
+
+	// fetch the repo to allow easy access to owner info (name, email, login, etc.)
+	user, _, err := client.Users.Get(ctx, org)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// validate we have access to the repository
+	_, r, err := client.Repositories.Get(ctx, org, repo)
+	if err != nil || r.StatusCode != http.StatusOK {
+		return nil, nil, err
+	}
+
+	return client, user, nil
+}
+
+func PointerTo[T any](s T) *T {
+	return &s
+}

--- a/providers/backend/s3/s3.go
+++ b/providers/backend/s3/s3.go
@@ -14,10 +14,11 @@ import (
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	k8syaml "sigs.k8s.io/yaml"
 
+	"capi-bootstrap/types"
 	capiYaml "capi-bootstrap/yaml"
 )
 
@@ -169,6 +170,10 @@ func (b *Backend) uploadFile(ctx context.Context, fileContent string, filePath s
 	return err
 }
 
+func (b *Backend) ListClusters(_ context.Context) ([]types.ClusterInfo, error) {
+	return nil, errors.New("[s3 backend] ListClusters not implemented")
+}
+
 func (b *Backend) WriteFiles(ctx context.Context, clusterName string, cloudInitConfig *capiYaml.Config) ([]string, error) {
 	downloadCmds := make([]string, len(cloudInitConfig.WriteFiles))
 	newFiles := make([]capiYaml.InitFile, len(cloudInitConfig.WriteFiles))
@@ -193,13 +198,13 @@ func (b *Backend) Delete(ctx context.Context, clusterName string) error {
 	if err != nil {
 		return fmt.Errorf("couldn't list objects: %v", err)
 	}
-	objectsToDelete := make([]types.ObjectIdentifier, *objects.KeyCount)
+	objectsToDelete := make([]s3types.ObjectIdentifier, *objects.KeyCount)
 	for i, object := range objects.Contents {
-		objectsToDelete[i] = types.ObjectIdentifier{Key: object.Key}
+		objectsToDelete[i] = s3types.ObjectIdentifier{Key: object.Key}
 	}
 	_, err = b.Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 		Bucket: &b.BucketName,
-		Delete: &types.Delete{
+		Delete: &s3types.Delete{
 			Objects: objectsToDelete,
 		},
 	})

--- a/providers/backend/types.go
+++ b/providers/backend/types.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
+	"capi-bootstrap/types"
 	capiYaml "capi-bootstrap/yaml"
 )
 
@@ -14,4 +15,5 @@ type Provider interface {
 	WriteConfig(ctx context.Context, clusterName string, config *v1.Config) error
 	WriteFiles(ctx context.Context, clusterName string, cloudInitFile *capiYaml.Config) ([]string, error)
 	Delete(ctx context.Context, clusterName string) error
+	ListClusters(context.Context) ([]types.ClusterInfo, error)
 }

--- a/providers/infrastructure/linode/files/capi-pivot-machine.yaml
+++ b/providers/infrastructure/linode/files/capi-pivot-machine.yaml
@@ -19,6 +19,11 @@ spec:
   clusterName: "[[[ .ClusterName ]]]"
   providerID: linode://{{ ds.meta_data.id }}
   version: "[[[ .K8sVersion ]]]"
+  [[[- if .SSHAuthorizedKeys ]]]
+  authorizedKeys:[[[ range .SSHAuthorizedKeys ]]]
+    - [[[ . ]]][[[ "\n" ]]]
+  [[[- end -]]]
+  [[[- end -]]]
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: LinodeMachine
@@ -35,3 +40,8 @@ spec:
   providerID: "linode://{{ ds.meta_data.id }}"
   region: "{{ ds.meta_data.region }}"
   type: g6-standard-6
+  [[[- if .SSHAuthorizedKeys ]]]
+  authorizedKeys:[[[ range .SSHAuthorizedKeys ]]]
+    - [[[ . ]]][[[ "\n" ]]]
+  [[[- end -]]]
+  [[[- end -]]]

--- a/providers/infrastructure/linode/linode_test.go
+++ b/providers/infrastructure/linode/linode_test.go
@@ -104,6 +104,8 @@ spec:
   clusterName: "test-cluster"
   providerID: linode://{{ ds.meta_data.id }}
   version: "1.30.0"
+  authorizedKeys:
+    - ssh-rsa blah
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: LinodeMachine
@@ -120,10 +122,12 @@ spec:
   providerID: "linode://{{ ds.meta_data.id }}"
   region: "{{ ds.meta_data.region }}"
   type: g6-standard-6
+  authorizedKeys:
+    - ssh-rsa blah
 `,
 	}
 	tests := []test{
-		{name: "success", input: types.Values{ClusterName: "test-cluster", K8sVersion: "1.30.0", BootstrapManifestDir: "/test-manifests/"}, want: ptr.To(expectedCapiPivotFile)},
+		{name: "success", input: types.Values{ClusterName: "test-cluster", K8sVersion: "1.30.0", BootstrapManifestDir: "/test-manifests/", SSHAuthorizedKeys: []string{"ssh-rsa blah"}}, want: ptr.To(expectedCapiPivotFile)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -412,7 +416,7 @@ spec:
 			Infra := Infrastructure{
 				Client:         tc.mockClient(ctx, t, mock),
 				Token:          "test-token",
-				AuthorizedKeys: "test-key",
+				AuthorizedKeys: []string{"test-key"},
 			}
 			err := Infra.PreDeploy(ctx, &tc.input)
 			if tc.wantErr == "" {
@@ -531,7 +535,7 @@ func TestCAPL_Deploy(t *testing.T) {
 					ID: 5678,
 				},
 				Token:          "test-token",
-				AuthorizedKeys: "test-key",
+				AuthorizedKeys: []string{"test-key"},
 			}
 			err := Infra.Deploy(ctx, &tc.input, metadata)
 			if tc.wantErr == "" {
@@ -734,7 +738,7 @@ func TestCAPL_Delete(t *testing.T) {
 			Infra := Infrastructure{
 				Client:         tc.mockClient(ctx, t, mock),
 				Token:          "test-token",
-				AuthorizedKeys: "test-key",
+				AuthorizedKeys: []string{"test-key"},
 			}
 			err := Infra.Delete(ctx, &tc.input, tc.force)
 			if tc.wantErr == "" {

--- a/types/types.go
+++ b/types/types.go
@@ -18,6 +18,8 @@ type Values struct {
 	Kubeconfig *v1.Config `json:"-"`
 	// K8sVersion is the version parsed from the providers.ControlPlane
 	K8sVersion string
+	// SSHAuthorizedKeys will pass a list of ssh public keys to a controlplane provider
+	SSHAuthorizedKeys []string
 	// ClusterKind is the Kind of infrastructure.cluster.x-k8s.io used for this cluster
 	ClusterKind string
 	// ClusterEndpoint is the IP address or hostname to be used to access the kubernetes cluster
@@ -30,4 +32,17 @@ type Values struct {
 	BootstrapManifestDir string
 	// Manifests is the separated list of all manifests parsed from the ManifestFile
 	Manifests []string `json:"-"`
+}
+
+type ClusterInfo struct {
+	Name  string
+	Nodes []*NodeInfo
+}
+
+type NodeInfo struct {
+	Name              string
+	Status            string
+	Version           string
+	ExternalIP        string
+	DaysSinceCreation string
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/client-go/tools/clientcmd/api"
+	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+// MergeAPIConfigIntoV1Config merges a clientcmd api.Config created via clientcmd.Load into a clientcmd v1 Config.
+// Set updateContext if the incoming api.Config should be set as the CurrentContext in the v1 Config that this function returns.
+func MergeAPIConfigIntoV1Config(apiConfig *api.Config, v1Config *apiv1.Config, updateContext bool) (*apiv1.Config, error) {
+	for k, v := range apiConfig.AuthInfos {
+		apiAuthInfo := apiv1.AuthInfo{}
+		rawV1AuthInfo, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(rawV1AuthInfo, &apiAuthInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		newAuthInfo := apiv1.NamedAuthInfo{
+			Name:     k,
+			AuthInfo: apiAuthInfo,
+		}
+		for _, authInfo := range v1Config.AuthInfos {
+			if !reflect.DeepEqual(authInfo, newAuthInfo) {
+				v1Config.AuthInfos = append(v1Config.AuthInfos, newAuthInfo)
+				continue
+			}
+		}
+	}
+
+	for k, v := range apiConfig.Clusters {
+		apiCluster := apiv1.Cluster{}
+		rawV1Cluster, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(rawV1Cluster, &apiCluster)
+		if err != nil {
+			return nil, err
+		}
+
+		newCluster := apiv1.NamedCluster{
+			Name:    k,
+			Cluster: apiCluster,
+		}
+		for _, cluster := range v1Config.Clusters {
+			if !reflect.DeepEqual(cluster, newCluster) {
+				v1Config.Clusters = append(v1Config.Clusters, newCluster)
+				continue
+			}
+		}
+	}
+
+	for k, v := range apiConfig.Contexts {
+		apiContext := apiv1.Context{}
+		rawV1Context, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(rawV1Context, &apiContext)
+		if err != nil {
+			return nil, err
+		}
+
+		newContext := apiv1.NamedContext{
+			Name:    k,
+			Context: apiContext,
+		}
+		for _, v1Context := range v1Config.Contexts {
+			if !reflect.DeepEqual(v1Context, newContext) {
+				v1Config.Contexts = append(v1Config.Contexts, newContext)
+				continue
+			}
+		}
+	}
+
+	for k, v := range apiConfig.Extensions {
+		ext := runtime.RawExtension{}
+		rawExt, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(rawExt, &ext)
+		if err != nil {
+			return nil, err
+		}
+		newExt := apiv1.NamedExtension{
+			Name:      k,
+			Extension: ext,
+		}
+		for _, extension := range v1Config.Extensions {
+			if !reflect.DeepEqual(extension, newExt) {
+				v1Config.Extensions = append(v1Config.Extensions, newExt)
+				continue
+			}
+		}
+	}
+
+	if updateContext {
+		v1Config.CurrentContext = apiConfig.CurrentContext
+	}
+
+	v1Config.APIVersion = apiv1.SchemeGroupVersion.Version
+	v1Config.Kind = "Config"
+	return v1Config, nil
+}

--- a/utils/list.go
+++ b/utils/list.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	k8snet "k8s.io/utils/net"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"capi-bootstrap/types"
+)
+
+func BuildNodeInfoList(ctx context.Context, kubeconfig []byte) ([]*types.NodeInfo, error) {
+	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	client := kubernetes.NewForConfigOrDie(config)
+
+	nodeList, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	nodeInfoList := make([]*types.NodeInfo, len(nodeList.Items))
+
+	for _, node := range nodeList.Items {
+		var status string
+
+		for _, cond := range node.Status.Conditions {
+			if cond.Reason == "KubeletReady" {
+				if cond.Status == "True" {
+					status = string(v1beta1.ReadyCondition)
+				} else {
+					status = "NotReady"
+				}
+				break
+			}
+		}
+
+		var extIP string
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == "ExternalIP" {
+				ip := net.ParseIP(addr.Address)
+				if k8snet.IsIPv4(ip) {
+					extIP = addr.Address
+					break
+				}
+				continue
+			}
+		}
+
+		var timestamp string
+		switch {
+		case time.Since(node.GetCreationTimestamp().Local()).Hours()/24 < 1:
+			timestamp = fmt.Sprintf("%.1fh", time.Since(node.GetCreationTimestamp().Local()).Hours())
+		case time.Since(node.GetCreationTimestamp().Local()).Hours()/24 > 1:
+			timestamp = fmt.Sprintf("%.2fd", time.Since(node.GetCreationTimestamp().Local()).Hours()/24)
+		case time.Since(node.GetCreationTimestamp().Local()).Hours() < 1:
+			timestamp = fmt.Sprintf("%fm", time.Since(node.GetCreationTimestamp().Local()).Minutes())
+		}
+		nodeInfoList = append(nodeInfoList, &types.NodeInfo{
+			Name:              node.Name,
+			Status:            status,
+			Version:           node.Status.NodeInfo.KubeletVersion,
+			ExternalIP:        extIP,
+			DaysSinceCreation: timestamp,
+		})
+	}
+	return nodeInfoList, nil
+}
+
+func TabWriteClusters(w io.Writer, clusters []types.ClusterInfo) error {
+	for _, cluster := range clusters {
+		fmt.Printf("Cluster: %s\n", cluster.Name)
+
+		numBytes, err := fmt.Fprintln(w, "Name\tStatus\tVersion\tExternal IP\tAge")
+		if err != nil || numBytes == 0 {
+			return err
+		}
+		for _, node := range cluster.Nodes {
+			numBytes, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", node.Name, node.Status,
+				node.Version, node.ExternalIP, node.DaysSinceCreation)
+			if err != nil || numBytes == 0 {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Add a github backend that writes state files to `clusters/$CLUSTER_NAME/kubeconfig.yaml`
- Add a `ListClusters` method to the `Provider` interface and add a full implementation for the github backend (actual output below)
- Add `SSHAuthorizedKeys` to the `Values` type and plumb it throughout the entire infrastructure ecosystem via `AUTHORIZED_KEYS` env variable. This includes adding a conditional check to `capi-pivot-machine.yaml` for populating the `AuthorizedKeys` field for `LinodeMachines`
- The github backend will now add the kubeconfigs for each cluster defined in the remote state to the state file by updating the `clusters/$CLUSTER_NAME/kubeconfig.yaml` file.
- created `utils/config.go` to house the `MergeAPIConfigIntoV1Config` func that merges a clientcmd `api.Config` created via `clientcmd.Load()` into a clientcmd `v1.Config`

Note: Only private github repos can be used with the `github` backend due to github's secret scanning blocking the kubeconfig upload via api due to potential secrets being present. This will be addressed and public repos _should_ be usable once encryption is added for the state files.

```shell
% clusterctl bootstrap list ross-test --backend github

Cluster: ross-test
Name                            Status  Version         External IP     Age
ross-test-bootstrap             Ready   v1.29.4+k3s1    172.234.205.99  5.1h
ross-test-control-plane-b9xrp   Ready   v1.29.4+k3s1    172.234.215.248 5.0h
ross-test-control-plane-mcg2r   Ready   v1.29.4+k3s1    172.232.10.129  5.0h
ross-test-md-0-d74gs-g6bqw      Ready   v1.29.4+k3s1    172.232.10.150  5.0h
ross-test-md-0-d74gs-kr9x2      Ready   v1.29.4+k3s1    172.234.215.223 5.0h
ross-test-md-0-d74gs-tdxj2      Ready   v1.29.4+k3s1    172.232.10.189  5.0h
``